### PR TITLE
fixed object returned by single item get

### DIFF
--- a/products/get.js
+++ b/products/get.js
@@ -23,7 +23,7 @@ module.exports.get = (event, context, callback) => {
         }
         const response = {
           statusCode: statusState,
-          body: statusState == 200 ? JSON.stringify(data) : null,
+          body: statusState == 200 ? JSON.stringify(data.Item) : null,
         };
         callback(null, response);
       }


### PR DESCRIPTION
before:

```json
{
    "Item": {
        "description": "testbeer",
        "id": "1cacf5ac-c0b1-4bfa-85b7-72ac373f10fa",
        "price": 123.1,
        "name": "Test Beer",
        "image": "example.com/0.png"
    }
}
```

after:

```json
{
    "description": "testbeer",
    "id": "1cacf5ac-c0b1-4bfa-85b7-72ac373f10fa",
    "price": 123.1,
    "name": "Test Beer",
    "image": "example.com/0.png"
}
```