### PR TITLE
adds authentication step

### DIFF
--- a/products/create.js
+++ b/products/create.js
@@ -2,6 +2,13 @@
 
 module.exports.create = (event, context, callback) => {
 
+  const sharedSecretKey = process.env.SHARED_SECRET_KEY || "";
+  const clientKey = event.headers.SHARED_SECRET_KEY || "";
+  if (sharedSecretKey == "")
+    callback('error');
+  if (clientKey == "" || clientKey != sharedSecretKey)
+    callback(null, {statusCode:401, body:JSON.stringify({"message":"unauthorized"})})
+
   var AWS = require("aws-sdk");
   var uuid = require('uuid');
 

--- a/products/delete.js
+++ b/products/delete.js
@@ -2,6 +2,13 @@
 
 module.exports.delete = (event, context, callback) => {
 
+  const sharedSecretKey = process.env.SHARED_SECRET_KEY || "";
+  const clientKey = event.headers.SHARED_SECRET_KEY || "";
+  if (sharedSecretKey == "")
+    callback('error');
+  if (clientKey == "" || clientKey != sharedSecretKey)
+    callback(null, {statusCode:401, body:JSON.stringify({"message":"unauthorized"})})
+
   var AWS = require("aws-sdk");
 
   var docClient = new AWS.DynamoDB.DocumentClient();

--- a/products/get.js
+++ b/products/get.js
@@ -2,6 +2,14 @@
 
 module.exports.get = (event, context, callback) => {
 
+  const sharedSecretKey = process.env.SHARED_SECRET_KEY || "";
+  const clientKey = event.headers.SHARED_SECRET_KEY || "";
+  if (sharedSecretKey == "")
+    callback('error');
+  if (clientKey == "" || clientKey != sharedSecretKey)
+    callback(null, {statusCode:401, body:JSON.stringify({"message":"unauthorized"})})
+
+
   var AWS = require("aws-sdk");
 
   var docClient = new AWS.DynamoDB.DocumentClient();

--- a/products/modify.js
+++ b/products/modify.js
@@ -2,6 +2,13 @@
 
 module.exports.modify = (event, context, callback) => {
 
+  const sharedSecretKey = process.env.SHARED_SECRET_KEY || "";
+  const clientKey = event.headers.SHARED_SECRET_KEY || "";
+  if (sharedSecretKey == "")
+    callback('error');
+  if (clientKey == "" || clientKey != sharedSecretKey)
+    callback(null, {statusCode:401, body:JSON.stringify({"message":"unauthorized"})})
+
   var AWS = require("aws-sdk");
 
   var docClient = new AWS.DynamoDB.DocumentClient({ convertEmptyValues: true });


### PR DESCRIPTION
closes #11
  
key has already been added to test and production environment
and shared with developers

without the proper key the response will have status 401 Unauthorised,
and if for some unexpected reason the key is unknown to the server it will give a generic 502 server error.

With the key the request will proceed as it did before
