### PR TITLE
makes the shared key header key case insensitive

### DIFF
--- a/products/auth.js
+++ b/products/auth.js
@@ -10,7 +10,9 @@ module.exports.auth = (event) => {
                     return self[key];
                 }
             }
-        }
+        },
+        enumerable = false,
+        writable = true
     });
 
     const sharedSecretKey = process.env.SHARED_SECRET_KEY || "";

--- a/products/auth.js
+++ b/products/auth.js
@@ -11,8 +11,8 @@ module.exports.auth = (event) => {
                 }
             }
         },
-        enumerable = false,
-        writable = true
+        enumerable: false,
+        writable: true
     });
 
     const sharedSecretKey = process.env.SHARED_SECRET_KEY || "";

--- a/products/auth.js
+++ b/products/auth.js
@@ -1,0 +1,26 @@
+module.exports.auth = (event) => {
+
+    // adds the function `getProp` to Object
+    // allowing for case insensitively getting keys 
+    Object.defineProperty(Object.prototype, "getProp", {
+        value: function (prop) {
+            var key,self = this;
+            for (key in self) {
+                if (key.toLowerCase() == prop.toLowerCase()) {
+                    return self[key];
+                }
+            }
+        },
+    });
+
+    const sharedSecretKey = process.env.SHARED_SECRET_KEY || "";
+    const clientKey = event.headers.getProp('shared_secret_key') || "";
+    
+    if (sharedSecretKey == "") {
+      return null;
+    }
+    if (clientKey == "" || clientKey != sharedSecretKey) {
+      return false;
+    }
+    return true;
+}

--- a/products/auth.js
+++ b/products/auth.js
@@ -10,11 +10,11 @@ module.exports.auth = (event) => {
                     return self[key];
                 }
             }
-        },
+        }
     });
 
     const sharedSecretKey = process.env.SHARED_SECRET_KEY || "";
-    const clientKey = event.headers.getProp('shared_secret_key') || "";
+    var clientKey = event.headers.getProp('shared_secret_key') || "";
     
     if (sharedSecretKey == "") {
       return null;

--- a/products/create.js
+++ b/products/create.js
@@ -2,13 +2,14 @@
 
 module.exports.create = (event, context, callback) => {
 
-  const sharedSecretKey = process.env.SHARED_SECRET_KEY || "";
-  const clientKey = event.headers.shared_secret_key || "";
-  if (sharedSecretKey == "") {
+  const auth = require("./auth");
+  const authorized = auth.auth(event);
+
+  if (authorized == null) {
     callback('error');
     return;
   }
-  if (clientKey == "" || clientKey != sharedSecretKey) {
+  if (!authorized) {
     callback(null, {statusCode:401, body:JSON.stringify({"message":"unauthorized"})});
     return;
   }

--- a/products/delete.js
+++ b/products/delete.js
@@ -2,13 +2,14 @@
 
 module.exports.delete = (event, context, callback) => {
 
-  const sharedSecretKey = process.env.SHARED_SECRET_KEY || "";
-  const clientKey = event.headers.shared_secret_key || "";
-  if (sharedSecretKey == "") {
+  const auth = require("./auth");
+  const authorized = auth.auth(event);
+
+  if (authorized == null) {
     callback('error');
     return;
   }
-  if (clientKey == "" || clientKey != sharedSecretKey) {
+  if (!authorized) {
     callback(null, {statusCode:401, body:JSON.stringify({"message":"unauthorized"})});
     return;
   }

--- a/products/get.js
+++ b/products/get.js
@@ -2,13 +2,14 @@
 
 module.exports.get = (event, context, callback) => {
 
-  const sharedSecretKey = process.env.SHARED_SECRET_KEY || "";
-  const clientKey = event.headers.shared_secret_key || "";
-  if (sharedSecretKey == "") {
+  const auth = require("./auth");
+  const authorized = auth.auth(event);
+
+  if (authorized == null) {
     callback('error');
     return;
   }
-  if (clientKey == "" || clientKey != sharedSecretKey) {
+  if (!authorized) {
     callback(null, {statusCode:401, body:JSON.stringify({"message":"unauthorized"})});
     return;
   }

--- a/products/modify.js
+++ b/products/modify.js
@@ -2,13 +2,14 @@
 
 module.exports.modify = (event, context, callback) => {
 
-  const sharedSecretKey = process.env.SHARED_SECRET_KEY || "";
-  const clientKey = event.headers.shared_secret_key || "";
-  if (sharedSecretKey == "") {
+  const auth = require("./auth");
+  const authorized = auth.auth(event);
+
+  if (authorized == null) {
     callback('error');
     return;
   }
-  if (clientKey == "" || clientKey != sharedSecretKey) {
+  if (!authorized) {
     callback(null, {statusCode:401, body:JSON.stringify({"message":"unauthorized"})});
     return;
   }


### PR DESCRIPTION
closes #26 

the `shared_secret_key` header key can now be other than lowercase 

also splits authorization into separate file, unsure if it should be in a different directory, now it is on the same as the API functions are i.e. `/products/auth.js`